### PR TITLE
Add a marker to the embedded map

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,7 +35,7 @@
 
 
       <section>
-<iframe width="425" height="350" frameborder="0" scrolling="no" marginheight="0" marginwidth="0" src="http://www.openstreetmap.org/export/embed.html?bbox=-0.12413799762725829%2C51.52615091188886%2C-0.11834442615509033%2C51.52889760160883&amp;layer=mapnik" style="border: 1px solid black"></iframe><br/><small><a href="http://www.openstreetmap.org/#map=18/51.52752/-0.12124">View Larger Map</a></small>
+<iframe width="425" height="350" frameborder="0" scrolling="no" marginheight="0" marginwidth="0" src="http://www.openstreetmap.org/export/embed.html?bbox=-0.12413799762725829%2C51.52615091188886%2C-0.11834442615509033%2C51.52889760160883&amp;layer=mapnik&amp;marker=51.527562657678075%2C-0.12049823999404907" style="border: 1px solid black"></iframe><br/><small><a href="http://www.openstreetmap.org/?mlat=51.7145&amp;mlon=5.3270#map=18/51.52752/-0.12124">View Larger Map</a></small>
       </section>
       <section>
 


### PR DESCRIPTION
The OpenStreetMap embed function supports a 'marker' parameter, so do this and we can see where exactly the Harrison bar is
